### PR TITLE
fix: Support AGP8 namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.dooboolab.flutterinapppurchase'
+    }
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
First, thanks for the great package.

Now, Flutter supports `AGP8`, so I try to use it.

But, I got the following error.

```
Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
ain
```

And, I realize `flutter_inapp_purchase` doesn't support the `namespace`.

This PR is not perfect to support the `AGP8`, but it can fix the `namespace` issue simply.