### PR TITLE
NullPointerException: offerToken is required for constructing ProductDetailsParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.6.2
+* On android for inapp products. Fixed NullPointerException: offerToken is required for constructing ProductDetailsParams
 ## 5.6.1
 * Erroneous duplicate item by @deakjahn in https://github.com/dooboolab-community/flutter_inapp_purchase/pull/441
 * Fixed consumable products reading on Android by @33-Elephants in https://github.com/dooboolab-community/flutter_inapp_purchase/pull/439

--- a/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
@@ -537,9 +537,10 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
                 if (offerToken == null) {
                     offerToken = selectedProductDetails.subscriptionOfferDetails!![0].offerToken
                 }
-
-                productDetailsParamsBuilder.setOfferToken(offerToken)
+            } else {
+                offerToken = selectedProductDetails.subscriptionOfferDetails!![0].offerToken
             }
+            productDetailsParamsBuilder.setOfferToken(offerToken)
 
             val productDetailsParamsList = listOf(productDetailsParamsBuilder.build())
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_inapp_purchase
 description: In App Purchase plugin for flutter. This project has been forked by
   react-native-iap and we are willing to share same experience with that on
   react-native.
-version: 5.6.1
+version: 5.6.2
 homepage: https://github.com/dooboolab/flutter_inapp_purchase/blob/main/pubspec.yaml
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
* On android for inapp products. 

Fixes dooboolab-community/flutter_inapp_purchase#475